### PR TITLE
chore(deps): enable automatic updates for GitHub Actions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+   - package-ecosystem: github-actions
+     directory: /
+     schedule:
+        interval: monthly
+     groups:
+        actions:
+           patterns:
+              - '*'

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '18.17.1'
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
         with:
           node-version: '18.17.1'
 


### PR DESCRIPTION

### 💚 Dependabot automatic updates
This PR enables automatic updates for GitHub Actions via [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).

Dependabot will periodically check for new versions of the actions and create a PR to update the version used in the repository.

This should help keeping your GitHub Actions up to date with the latest versions of the actions.

#### 🔍 How was this detected and generated?
This PR was generated using [ethpandaops/github-actions-checker](https://github.com/ethpandaops/github-actions-checker).
